### PR TITLE
Sample set_file_paths signature

### DIFF
--- a/pipelines/atacseq.py
+++ b/pipelines/atacseq.py
@@ -46,12 +46,12 @@ class ATACseqSample(Sample):
 	def __repr__(self):
 		return "ATAC-seq sample '%s'" % self.sample_name
 
-	def set_file_paths(self):
+	def set_file_paths(self, project):
 		"""
 		Sets the paths of all files for this sample.
 		"""
 		# Inherit paths from Sample by running Sample's set_file_paths()
-		super(ATACseqSample, self).set_file_paths()
+		super(ATACseqSample, self).set_file_paths(project)
 
 		# Files in the root of the sample dir
 		self.fastqc = os.path.join(self.paths.sample_root, self.sample_name + ".fastqc.zip")
@@ -123,8 +123,8 @@ class DNaseSample(ATACseqSample):
 	def __repr__(self):
 		return "DNase-seq sample '%s'" % self.sample_name
 
-	def set_file_paths(self):
-		super(DNaseSample, self).set_file_paths()
+	def set_file_paths(self, project):
+		super(DNaseSample, self).set_file_paths(project)
 
 
 def report_dict(pipe, stats_dict):
@@ -453,7 +453,7 @@ def main():
 		sample.paired = False
 
 	# Set file paths
-	sample.set_file_paths()
+	sample.set_file_paths(sample.prj)
 	# sample.make_sample_dirs()  # should be fixed to check if values of paths are strings and paths indeed
 
 	# Start Pypiper object

--- a/pipelines/chipseq.py
+++ b/pipelines/chipseq.py
@@ -451,10 +451,10 @@ def main():
 	# Read in yaml configs
 	series = pd.Series(yaml.load(open(args.sample_config, "r")))
 	# Create Sample object
-	if series["library"] != "ChIPmentation":
-		sample = ChIPseqSample(series)
-	else:
+	if series.library == "ChIPmentation":
 		sample = ChIPmentation(series)
+	else:
+		sample = ChIPseqSample(series)
 
 	# Check if merged
 	if len(sample.data_path.split(" ")) > 1:

--- a/pipelines/chipseq.py
+++ b/pipelines/chipseq.py
@@ -70,12 +70,13 @@ class ChIPseqSample(Sample):
 	def __repr__(self):
 		return "ChIP-seq sample '%s'" % self.sample_name
 
-	def set_file_paths(self):
+	def set_file_paths(self, project):
 		"""
 		Sets the paths of all files for this sample.
 		"""
-		# Inherit paths from Sample by running Sample's set_file_paths()
-		super(ChIPseqSample, self).set_file_paths()
+
+		# Get paths container structure and any contents used by any Sample.
+		super(ChIPseqSample, self).set_file_paths(project)
 
 		# Files in the root of the sample dir
 		self.fastqc = os.path.join(self.paths.sample_root, self.sample_name + ".fastqc.zip")
@@ -140,8 +141,8 @@ class ChIPmentation(ChIPseqSample):
 	def __repr__(self):
 		return "ChIPmentation sample '%s'" % self.sample_name
 
-	def set_file_paths(self):
-		super(ChIPmentation, self).set_file_paths()
+	def set_file_paths(self, project):
+		super(ChIPmentation, self).set_file_paths(project)
 
 
 def bamToBigWig(inputBam, outputBigWig, genomeSizes, genome, tagmented=False, normalize=False, norm_factor=1000000):
@@ -470,7 +471,7 @@ def main():
 		sample.paired = False
 
 	# Set file paths
-	sample.set_file_paths()
+	sample.set_file_paths(sample.prj)
 	# sample.make_sample_dirs()  # should be fixed to check if values of paths are strings and paths indeed
 
 	# Start Pypiper object


### PR DESCRIPTION
Signature for method `set_file_paths` on `Sample` changed a little in `looper` v0.6. This updates the usage in a couple of the pipelines. Fix #2 

See https://github.com/epigen/looper/issues/144 and https://github.com/epigen/looper/issues/150 for discussion and https://github.com/epigen/looper/commit/fa7989e0456cad1934fa183c6a9a4ea615f5dea3 for the change